### PR TITLE
[#9] 라우팅 이슈 수정

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -87,7 +87,7 @@ export default () => {
       document.body.addEventListener('click', (e) => {
         const { target } = e;
 
-        if (target.matches(A_SELECTOR)) {
+        if (target.closest(A_SELECTOR)) {
           e.preventDefault();
           router.navigate(target.href);
         }


### PR DESCRIPTION
정확히 `a` 태그를 클릭하지 않으면 아티클 페이지로 라우팅이 안되는 이슈 해결.