### PR TITLE
[#13] 라우팅 이슈 수정

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -89,9 +89,7 @@ export default () => {
 
         if (target.closest(A_SELECTOR)) {
           e.preventDefault();
-          const href = target.href
-            ? target.href
-            : target.closest(A_SELECTOR).href;
+          const href = target.closest(A_SELECTOR).href;
           router.navigate(href);
         }
       });

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -89,7 +89,10 @@ export default () => {
 
         if (target.closest(A_SELECTOR)) {
           e.preventDefault();
-          router.navigate(target.href);
+          const href = target.href
+            ? target.href
+            : target.closest(A_SELECTOR).href;
+          router.navigate(href);
         }
       });
     },


### PR DESCRIPTION
## 이슈

`target`에 `href`가 없는 경우 원하는 대로 페이지가 이동하지 않음.

## 해결 방법

`target`에 `href`가 없는 경우 부모의 `href`를 따라가게 수정.