### PR TITLE
[#18] 이전 페이지 이동할 때 이전 페이지 내용이 그대로 남아있는 이슈

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,8 @@
 const start = () => {
   const app = document.getElementById('root');
 
+  app.innerHTML = '';
+
   const header = document.createElement('header');
   const mainSection = document.createElement('section');
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,5 @@
 const start = () => {
-  const app = document.getElementById('root');
-
-  app.innerHTML = '';
+  const homeContainer = document.createElement('div');
 
   const header = document.createElement('header');
   const mainSection = document.createElement('section');
@@ -21,8 +19,10 @@ const start = () => {
   mainSection.appendChild(mainTitle);
   mainSection.appendChild(mainContainer);
 
-  app.appendChild(header);
-  app.appendChild(mainSection);
+  homeContainer.appendChild(header);
+  homeContainer.appendChild(mainSection);
+
+  return homeContainer;
 };
 
 // document.addEventListener('DOMContentLoaded', start);

--- a/src/router/pages.js
+++ b/src/router/pages.js
@@ -15,7 +15,8 @@ const datas = () =>
 
 export default (container) => {
   const home = () => {
-    start();
+    container.replaceChildren(start());
+
     fetchData().then((articles) => {
       const listItems = createArticleListItem(articles);
       addListItems(listItems);


### PR DESCRIPTION
### 이슈 넘버 
#18 

### 이슈 내용

아티클 페이지 -> 메인 페이지 이동할 때 아티클 페이지의 내용이 사라지지 않고 메인 페이지의 내용이 밑에 쌓임

### 변경 후 

메인 페이지로 넘어올 때 `app` 의 `html`을 모두 비워주고 다시 메인 페이지 요소를 추가한다.